### PR TITLE
Changes to fix issues running in dev.

### DIFF
--- a/herring/herring/settings.py
+++ b/herring/herring/settings.py
@@ -162,9 +162,9 @@ HERRING_FUCK_OAUTH = json.loads(env.get_value('FUCK_OAUTH', default='{}'))
 HERRING_HUNT_ID = int(env.get_value('HUNT_ID', default=0))
 HERRING_TEAM_NAME = env.get_value('TEAM_NAME', default="Non-Abelian Rage Theory")
 
-HERRING_ACTIVATE_GAPPS = env.bool('ACTIVATE_GAPPS', default=True)
-HERRING_ACTIVATE_SLACK = env.bool('ACTIVATE_SLACK', default=True)
-HERRING_ACTIVATE_DISCORD = env.bool('ACTIVATE_DISCORD', default=True)
+HERRING_ACTIVATE_GAPPS = env.bool('ACTIVATE_GAPPS', default=False)
+HERRING_ACTIVATE_SLACK = env.bool('ACTIVATE_SLACK', default=False)
+HERRING_ACTIVATE_DISCORD = env.bool('ACTIVATE_DISCORD', default=False)
 
 HERRING_SOLVERTOOLS_URL = env.get_value('SOLVERTOOLS_URL', default="http://ireproof.org/")
 

--- a/herring/puzzles/tasks.py
+++ b/herring/puzzles/tasks.py
@@ -421,6 +421,8 @@ def update_slack_channel_membership(channel_id):
 
 @ttl_cache(maxsize=512, ttl=3600)
 def channel_name(channel_id):
+    if not settings.HERRING_ACTIVATE_SLACK:
+        return None
     result = SLACK.conversations.info(channel_id)
     if result.successful:
         return result.body['channel']['name']


### PR DESCRIPTION
(1) Default integrations to off:

Since by default we don't have any credentials for our integrations, it doesn't make much sense for them to be enabled by default. It just breaks the ability to easily run things in dev. (I know I could set env vars, but that would require me to figure out how to persistently set env vars in dev...)

(I went ahead and added ACTIVATE_DISCORD and ACTIVATE_GAPPS to the config for staging, with the value "1", so that this change doesn't break them yet.)

(2) Stop poking Slack when there's no Slack.

I'm not sure why this doesn't break in prod (or maybe it does and we're just ignoring the logged errors? But maybe there's some other thing that prevents this codepath from running, not sure.)